### PR TITLE
Update aptos-protos to upstream branch test5

### DIFF
--- a/aptos-indexer-processors-sdk/Cargo.toml
+++ b/aptos-indexer-processors-sdk/Cargo.toml
@@ -31,7 +31,7 @@ testing-framework = { path = "testing-framework" }
 
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-protos = { git = "https://github.com/larry-aptos/aptos-core.git", rev = "5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb" }
+aptos-protos = { git = "https://github.com/larry-aptos/aptos-core.git", rev = "681726122d61cec669b85d1b52cda59ac4350bdd" }
 aptos-system-utils = { git = "https://github.com/larry-aptos/aptos-core.git", rev = "4541add3fd29826ec57f22658ca286d2d6134b93" }
 async-trait = "0.1.80"
 autometrics = { version = "1.0.1", features = ["prometheus-exporter"] }


### PR DESCRIPTION
This PR updates aptos-protos to new version.